### PR TITLE
Fixed Bug in ax.grid

### DIFF
--- a/aimstools/bandstructures/utilities.py
+++ b/aimstools/bandstructures/utilities.py
@@ -509,7 +509,7 @@ class BandStructurePlot:
         self.ax.tick_params(axis="x", which="both", length=0)
         if self.show_grid_lines and self.main:
             self.ax.grid(
-                b=self.show_grid_lines,
+                visible=self.show_grid_lines,
                 which="major",
                 axis=self.grid_lines_axes,
                 linestyle=self.grid_linestyle,
@@ -718,7 +718,7 @@ class MullikenBandStructurePlot(BandStructurePlot):
         self.ax.tick_params(axis="x", which="both", length=0)
         if self.show_grid_lines and self.main:
             self.ax.grid(
-                b=self.show_grid_lines,
+                visible=self.show_grid_lines,
                 which="major",
                 axis=self.grid_lines_axes,
                 linestyle=self.grid_linestyle,

--- a/aimstools/density_of_states/utilities.py
+++ b/aimstools/density_of_states/utilities.py
@@ -443,7 +443,7 @@ class DOSPlot:
             self._show_fermi_level()
         if self.show_grid_lines and self.main:
             self.ax.grid(
-                b=self.show_grid_lines,
+                visible=self.show_grid_lines,
                 which="major",
                 axis=self.grid_lines_axes,
                 linestyle=self.grid_linestyle,


### PR DESCRIPTION
There was an invalid parameter in `ax.grid(b=self.show_grid_lines)` function in utilities, which is changed to `ax.grid(visible=self.show_grid_lines)`.